### PR TITLE
Consolidate user provided configs in node

### DIFF
--- a/cmd/bench/bench_test.go
+++ b/cmd/bench/bench_test.go
@@ -17,9 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ryandielhenn/zephyrcache/pkg/kv"
 	"github.com/ryandielhenn/zephyrcache/pkg/node"
-	"github.com/ryandielhenn/zephyrcache/pkg/ring"
 )
 
 var (
@@ -49,12 +47,11 @@ func startNode(id, seedGossipAddr string) cacheNode {
 	}
 	gossipPort := strconv.Itoa(uconn.LocalAddr().(*net.UDPAddr).Port)
 	gossipAddr := uconn.LocalAddr().String()
+	os.Setenv("GOSSIP_PORT", gossipPort)
+	os.Setenv("SELF_ID", id)
+	os.Setenv("SELF_ADDR", httpAddr)
 
-	store := kv.NewStore(64 << 20)
-	r := ring.New(128, ring.FNV32a)
-	r.Add(id, httpAddr)
-
-	n := node.NewNode(store, r, id, httpAddr, gossipPort, *nReplicas)
+	n := node.NewNode(node.Config())
 	go node.StartGossipListener(n)
 	go node.StartGossipPinger(n,
 		node.WithPeriod(50*time.Millisecond),

--- a/cmd/bench/bench_test.go
+++ b/cmd/bench/bench_test.go
@@ -47,11 +47,10 @@ func startNode(id, seedGossipAddr string) cacheNode {
 	}
 	gossipPort := strconv.Itoa(uconn.LocalAddr().(*net.UDPAddr).Port)
 	gossipAddr := uconn.LocalAddr().String()
-	os.Setenv("GOSSIP_PORT", gossipPort)
-	os.Setenv("SELF_ID", id)
-	os.Setenv("SELF_ADDR", httpAddr)
 
-	n := node.NewNode(node.Config())
+	config := node.ConfigWithOpts(id, httpAddr, gossipPort, *nReplicas, 50)
+
+	n := node.NewNode(config)
 	go node.StartGossipListener(n)
 	go node.StartGossipPinger(n,
 		node.WithPeriod(50*time.Millisecond),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -59,55 +59,55 @@ func main() {
 		return
 	}
 
-	// 3. Wire up client facing endpoints
+	// 3. Wire up node facing endpoints
 	go func() {
-		clientMux := http.NewServeMux()
-		clientMux.HandleFunc("/healthz", n.Healthz)
-		clientMux.HandleFunc("/info", n.Info)
-		clientMux.Handle("/metrics", telemetry.MetricsHandler())
-		clientMux.HandleFunc("/kv/", func(w http.ResponseWriter, req *http.Request) {
-			op := methodToOp(req.Method) // "get" | "put" | "post" | "delete" | "other"
-			telemetry.Instrument(op, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				slog.Info("Received HTTP KV Request", "type", r.Method)
-				switch r.Method {
-				case http.MethodPut, http.MethodPost:
-					n.Put(w, r)
-				case http.MethodGet:
-					n.Get(w, r)
-				case http.MethodDelete:
-					n.Del(w, r)
-				default:
-					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-				}
-			})).ServeHTTP(w, req)
+		peerMux := http.NewServeMux()
+		peerMux.HandleFunc("/replica/", func(w http.ResponseWriter, req *http.Request) {
+			slog.Info("Received HTTP Replica Request", "type", req.Method)
+			switch req.Method {
+			case http.MethodPut, http.MethodPost:
+				n.PutReplica(w, req)
+			case http.MethodDelete:
+				n.DelReplica(w, req)
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
 		})
-		clientFacingAddr := ":8080"
-		slog.Info("ZephyrCache node listening to clients on", "addr", clientFacingAddr)
-		if err := http.ListenAndServe(clientFacingAddr, clientMux); err != nil {
+
+		peerFacingAddr := ":8081"
+		slog.Info("ZephyrCache node listening to peers on", "addr", peerFacingAddr)
+		if err := http.ListenAndServe(peerFacingAddr, peerMux); err != nil {
 			log.Fatal(err.Error())
 		}
-
 	}()
 
-	// 3. Wire up node facing endpoints
-	peerMux := http.NewServeMux()
-	peerMux.HandleFunc("/replica/", func(w http.ResponseWriter, req *http.Request) {
-		slog.Info("Received HTTP Replica Request", "type", req.Method)
-		switch req.Method {
-		case http.MethodPut, http.MethodPost:
-			n.PutReplica(w, req)
-		case http.MethodDelete:
-			n.DelReplica(w, req)
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		}
+	// 4. Wire up client facing endpoints
+	clientMux := http.NewServeMux()
+	clientMux.HandleFunc("/healthz", n.Healthz)
+	clientMux.HandleFunc("/info", n.Info)
+	clientMux.Handle("/metrics", telemetry.MetricsHandler())
+	clientMux.HandleFunc("/kv/", func(w http.ResponseWriter, req *http.Request) {
+		op := methodToOp(req.Method) // "get" | "put" | "post" | "delete" | "other"
+		telemetry.Instrument(op, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			slog.Info("Received HTTP KV Request", "type", r.Method)
+			switch r.Method {
+			case http.MethodPut, http.MethodPost:
+				n.Put(w, r)
+			case http.MethodGet:
+				n.Get(w, r)
+			case http.MethodDelete:
+				n.Del(w, r)
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
+		})).ServeHTTP(w, req)
 	})
-
-	peerFacingAddr := ":8081"
-	slog.Info("ZephyrCache node listening to peers on", "addr", peerFacingAddr)
-	if err := http.ListenAndServe(peerFacingAddr, peerMux); err != nil {
+	clientFacingAddr := ":8080"
+	slog.Info("ZephyrCache node listening to clients on", "addr", clientFacingAddr)
+	if err := http.ListenAndServe(clientFacingAddr, clientMux); err != nil {
 		log.Fatal(err.Error())
 	}
+
 }
 
 func methodToOp(m string) string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,32 +1,20 @@
 package main
 
 import (
-	"cmp"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ryandielhenn/zephyrcache/internal/telemetry"
-	"github.com/ryandielhenn/zephyrcache/pkg/kv"
 	"github.com/ryandielhenn/zephyrcache/pkg/node"
-	"github.com/ryandielhenn/zephyrcache/pkg/ring"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func main() {
-	// 1. Initialize this node with routing ring and key value store
-	store := kv.NewStore(64 << 20) // 64MB default cap for MVP
-	r := ring.New(128, ring.FNV32a)
-	id := os.Getenv("SELF_ID")
-	addr := os.Getenv("SELF_ADDR")
-	seedAddr := os.Getenv("SEED_ADDR")
-	etcdEndpoints := os.Getenv("ETCD_ENDPOINTS")
 	membershipService := os.Getenv("DISCOVERY")
-	gossipPort := cmp.Or(os.Getenv("GOSSIP_PORT"), "4000")
 	var level slog.Level
 	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
 		err := level.UnmarshalText([]byte(lvl))
@@ -37,18 +25,12 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: level,
 	})))
-	replicationFactor, err := strconv.Atoi(os.Getenv("REPLICATION_FACTOR"))
-	if err != nil {
-		slog.Warn("REPLICATION_FACTOR should be an int, could not parse, defaulting to 3")
-		replicationFactor = 3
-	}
-
 	// 2. Connect to cluster
-	r.Add(id, addr)
-	n := node.NewNode(store, r, id, node.NormalizeHostPort(addr, "8080"), gossipPort, replicationFactor)
+	n := node.NewNode(node.Config())
 	switch membershipService {
 	case "etcd":
 		slog.Info("[Boot] creating etcd client")
+		etcdEndpoints := os.Getenv("ETCD_ENDPOINTS")
 		cli, err := clientv3.New(clientv3.Config{
 			Endpoints:   strings.Split(etcdEndpoints, ","),
 			DialTimeout: 5 * time.Second,
@@ -62,6 +44,7 @@ func main() {
 		node.WatchPeers(n, cli)
 	case "gossip":
 		go node.StartGossipListener(n)
+		seedAddr := os.Getenv("SEED_ADDR")
 		if seedAddr != "" {
 			n.ConnectToCluster(seedAddr, 200*time.Millisecond)
 		}
@@ -100,7 +83,7 @@ func main() {
 		})
 		clientFacingAddr := ":8080"
 		slog.Info("ZephyrCache node listening to clients on", "addr", clientFacingAddr)
-		if err := http.ListenAndServe(addr, clientMux); err != nil {
+		if err := http.ListenAndServe(clientFacingAddr, clientMux); err != nil {
 			log.Fatal(err.Error())
 		}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,7 +107,6 @@ func main() {
 	if err := http.ListenAndServe(clientFacingAddr, clientMux); err != nil {
 		log.Fatal(err.Error())
 	}
-
 }
 
 func methodToOp(m string) string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,7 +48,6 @@ func main() {
 	n := node.NewNode(store, r, id, node.NormalizeHostPort(addr, "8080"), gossipPort, replicationFactor)
 	switch membershipService {
 	case "etcd":
-		// Create etcd client
 		slog.Info("[Boot] creating etcd client")
 		cli, err := clientv3.New(clientv3.Config{
 			Endpoints:   strings.Split(etcdEndpoints, ","),
@@ -77,28 +76,39 @@ func main() {
 		return
 	}
 
-	// 3. Wire up HTTP node endpoints
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", n.Healthz)
-	mux.HandleFunc("/info", n.Info)
-	mux.Handle("/metrics", telemetry.MetricsHandler())
-	mux.HandleFunc("/kv/", func(w http.ResponseWriter, req *http.Request) {
-		op := methodToOp(req.Method) // "get" | "put" | "post" | "delete" | "other"
-		telemetry.Instrument(op, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			slog.Info("Received HTTP KV Request", "type", r.Method)
-			switch r.Method {
-			case http.MethodPut, http.MethodPost:
-				n.Put(w, r)
-			case http.MethodGet:
-				n.Get(w, r)
-			case http.MethodDelete:
-				n.Del(w, r)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			}
-		})).ServeHTTP(w, req)
-	})
-	mux.HandleFunc("/replica/", func(w http.ResponseWriter, req *http.Request) {
+	// 3. Wire up client facing endpoints
+	go func() {
+		clientMux := http.NewServeMux()
+		clientMux.HandleFunc("/healthz", n.Healthz)
+		clientMux.HandleFunc("/info", n.Info)
+		clientMux.Handle("/metrics", telemetry.MetricsHandler())
+		clientMux.HandleFunc("/kv/", func(w http.ResponseWriter, req *http.Request) {
+			op := methodToOp(req.Method) // "get" | "put" | "post" | "delete" | "other"
+			telemetry.Instrument(op, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				slog.Info("Received HTTP KV Request", "type", r.Method)
+				switch r.Method {
+				case http.MethodPut, http.MethodPost:
+					n.Put(w, r)
+				case http.MethodGet:
+					n.Get(w, r)
+				case http.MethodDelete:
+					n.Del(w, r)
+				default:
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				}
+			})).ServeHTTP(w, req)
+		})
+		clientFacingAddr := ":8080"
+		slog.Info("ZephyrCache node listening to clients on", "addr", clientFacingAddr)
+		if err := http.ListenAndServe(addr, clientMux); err != nil {
+			log.Fatal(err.Error())
+		}
+
+	}()
+
+	// 3. Wire up node facing endpoints
+	peerMux := http.NewServeMux()
+	peerMux.HandleFunc("/replica/", func(w http.ResponseWriter, req *http.Request) {
 		slog.Info("Received HTTP Replica Request", "type", req.Method)
 		switch req.Method {
 		case http.MethodPut, http.MethodPost:
@@ -110,9 +120,9 @@ func main() {
 		}
 	})
 
-	addr = ":8080"
-	slog.Info("ZephyrCache node listening on", "addr", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	peerFacingAddr := ":8081"
+	slog.Info("ZephyrCache node listening to peers on", "addr", peerFacingAddr)
+	if err := http.ListenAndServe(peerFacingAddr, peerMux); err != nil {
 		log.Fatal(err.Error())
 	}
 }

--- a/pkg/node/etcd_handlers.go
+++ b/pkg/node/etcd_handlers.go
@@ -23,8 +23,9 @@ func BootstrapPeers(node *Node, cli *clientv3.Client) func() {
 		node.addPeer(nodeID, peerHP)
 	}
 
-	slog.Info("[Boot] registering, with etcd", "node.id", node.id, "node.addr", node.addr)
-	leaseId, cancel, err := discovery.RegisterNode(cli, node.id, node.addr, 10)
+	config := node.config
+	slog.Info("[Boot] registering, with etcd", "node.id", config.id, "node.addr", config.addr)
+	leaseId, cancel, err := discovery.RegisterNode(cli, config.id, config.addr, 10)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/node/gossip_handlers.go
+++ b/pkg/node/gossip_handlers.go
@@ -54,7 +54,7 @@ func (n *Node) handlePing(msg *gossip.Message) {
 	message := gossip.NewMessage(
 		gossip.PingAck,
 		msg.SubjectId,
-		n.id,
+		n.config.id,
 		msg.OriginId,
 		payload,
 	)
@@ -70,7 +70,7 @@ func (n *Node) handlePingReq(msg *gossip.Message) {
 	message := gossip.NewMessage(
 		gossip.Ping,
 		msg.SubjectId,
-		n.id,
+		n.config.id,
 		msg.OriginId,
 		payload,
 	)
@@ -79,7 +79,7 @@ func (n *Node) handlePingReq(msg *gossip.Message) {
 
 func (n *Node) handlePingAck(msg *gossip.Message) {
 	// handle ack at node that requested it
-	if msg.OriginId == n.id {
+	if msg.OriginId == n.config.id {
 		if n.targetPeer == msg.SubjectId {
 			if n.timeout != nil {
 				n.timeout.Stop()
@@ -99,7 +99,7 @@ func (n *Node) handlePingAck(msg *gossip.Message) {
 	message := gossip.NewMessage(
 		gossip.PingAck,
 		msg.SubjectId,
-		n.id,
+		n.config.id,
 		msg.OriginId,
 		payload,
 	)
@@ -127,7 +127,7 @@ func (n *Node) handlePayload(msg *gossip.MessagePayload, sourceId string) {
 
 func (n *Node) handleAliveStatus(id string, updatedPeer peer.Peer, sourceId string) {
 	// drop payloads about yourself
-	if id == n.id {
+	if id == n.config.id {
 		return
 	}
 
@@ -136,8 +136,8 @@ func (n *Node) handleAliveStatus(id string, updatedPeer peer.Peer, sourceId stri
 	currentPeer, ok := n.peers[id]
 	if !ok && id == sourceId {
 		peers := n.getPeerMap()
-		peers[n.id] = peer.Peer{
-			Addr:        n.addr,
+		peers[n.config.id] = peer.Peer{
+			Addr:        n.config.addr,
 			Status:      peer.Alive,
 			Incarnation: n.incarnation,
 		}
@@ -161,14 +161,14 @@ func (n *Node) handleAliveStatus(id string, updatedPeer peer.Peer, sourceId stri
 
 func (n *Node) handleSuspectedStatus(id string, updatedPeer peer.Peer) {
 	// drop payloads about yourself
-	if id == n.id {
+	if id == n.config.id {
 		// refute updates saying you are suspected
 		if updatedPeer.Incarnation == n.incarnation {
 			n.incarnation += 1
 		}
 		peers := map[string]peer.Peer{
-			n.id: {
-				Addr:        n.addr,
+			n.config.id: {
+				Addr:        n.config.addr,
 				Status:      peer.Alive,
 				Incarnation: n.incarnation,
 			},
@@ -230,7 +230,7 @@ func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 		return
 	}
 
-	udpAddr, err := net.ResolveUDPAddr("udp", OverrideHostPort(addr, n.gossipPort))
+	udpAddr, err := net.ResolveUDPAddr("udp", OverrideHostPort(addr, n.config.gossipPort))
 	if err != nil {
 		return
 	}
@@ -256,8 +256,8 @@ func (n *Node) attemptConnectToCluster(addr string) bool {
 	}
 
 	peers := map[string]peer.Peer{
-		n.id: {
-			Addr:        n.addr,
+		n.config.id: {
+			Addr:        n.config.addr,
 			Status:      peer.Alive,
 			Incarnation: 0,
 		},
@@ -266,8 +266,8 @@ func (n *Node) attemptConnectToCluster(addr string) bool {
 	message := gossip.NewMessage(
 		gossip.Ping,
 		"",
-		n.id,
-		n.id,
+		n.config.id,
+		n.config.id,
 		payload,
 	)
 	n.sendGossip(message, addr)
@@ -285,7 +285,7 @@ func (n *Node) ConnectToCluster(addr string, attemptPeriod time.Duration) {
 }
 
 func StartGossipListener(node *Node) {
-	address := net.JoinHostPort("", node.gossipPort)
+	address := net.JoinHostPort("", node.config.gossipPort)
 
 	addr, err := net.ResolveUDPAddr("udp", address)
 	if err != nil {
@@ -396,8 +396,8 @@ func runGossipPing(node *Node, cfg *pingerConfig) {
 	message := gossip.NewMessage(
 		gossip.Ping,
 		node.targetPeer,
-		node.id,
-		node.id,
+		node.config.id,
+		node.config.id,
 		payload,
 	)
 	node.sendGossip(message, peerBody.Addr)
@@ -420,8 +420,8 @@ func runGossipPing(node *Node, cfg *pingerConfig) {
 			message := gossip.NewMessage(
 				gossip.PingReq,
 				targetPeer,
-				node.id,
-				node.id,
+				node.config.id,
+				node.config.id,
 				payload,
 			)
 			node.sendGossip(message, peerBody.Addr)

--- a/pkg/node/http_handlers.go
+++ b/pkg/node/http_handlers.go
@@ -21,13 +21,13 @@ func (s *Node) Healthz(w http.ResponseWriter, _ *http.Request) {
 }
 
 // info writes a JSON payload with the process ID, current time, and KV item count.
-func (s *Node) Info(w http.ResponseWriter, _ *http.Request) {
+func (n *Node) Info(w http.ResponseWriter, _ *http.Request) {
 	type resp struct {
 		PID   int       `json:"pid"`
 		Now   time.Time `json:"now"`
 		Items int       `json:"items"`
 	}
-	data, _ := json.Marshal(resp{PID: os.Getpid(), Now: time.Now(), Items: s.kv.Len()})
+	data, _ := json.Marshal(resp{PID: os.Getpid(), Now: time.Now(), Items: n.kv.Len()})
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write(data)
 	if err != nil {
@@ -36,14 +36,14 @@ func (s *Node) Info(w http.ResponseWriter, _ *http.Request) {
 }
 
 // forward forwards a http request to the Node that owns the key
-func (s *Node) Forward(w http.ResponseWriter, req *http.Request, owner string) {
+func (n *Node) Forward(w http.ResponseWriter, req *http.Request, owner string) {
 	if owner == "" {
 		http.Error(w, "no owner for key", http.StatusServiceUnavailable)
 		return
 	}
 
 	hostport := NormalizeHostPort(owner, "8080")
-	if NormalizeHostPort(s.addr, "8080") == hostport {
+	if NormalizeHostPort(n.config.addr, "8080") == hostport {
 		// last-resort safety; shouldn’t happen if handler compare is correct
 		http.Error(w, "refusing to forward to self", http.StatusInternalServerError)
 		return
@@ -103,7 +103,7 @@ func (n *Node) Put(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	selfAddr := NormalizeHostPort(n.addr, "8080")
+	selfAddr := NormalizeHostPort(n.config.addr, "8080")
 	var wg sync.WaitGroup
 	for _, repAddr := range replicaAddrs {
 		wg.Add(1)
@@ -180,7 +180,7 @@ func (n *Node) Del(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	selfAddr := NormalizeHostPort(n.addr, "8080")
+	selfAddr := NormalizeHostPort(n.config.addr, "8080")
 	var wg sync.WaitGroup
 	for _, addr := range replicaAddrs {
 		wg.Add(1)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -14,33 +14,41 @@ import (
 )
 
 type Node struct {
-	kv           *kv.Store
-	ring         *ring.HashRing
-	gossipQueue  []*gossip.MessagePayload
+	kv          *kv.Store
+	ring        *ring.HashRing
+	gossipQueue []*gossip.MessagePayload
+	peers       map[string]peer.Peer
+	incarnation int
+	targetPeer  string
+	timeout     *time.Timer
+	mu          sync.Mutex
+	config      *NodeConfig
+}
+
+type NodeConfig struct {
 	maxGossipLen int
-	targetPeer   string
-	peers        map[string]peer.Peer
 	id           string
 	addr         string
 	nReplicas    int
-	incarnation  int
-	timeout      *time.Timer
 	gossipPort   string
-	mu           sync.Mutex
 }
 
 func NewNode(store *kv.Store, r *ring.HashRing, id string, addr string, gossipPort string, replicationFactor int) *Node {
-	return &Node{
-		kv:           store,
-		ring:         r,
-		gossipQueue:  make([]*gossip.MessagePayload, 0),
+	config := &NodeConfig{
 		maxGossipLen: 50,
-		peers:        make(map[string]peer.Peer),
 		id:           id,
 		addr:         addr,
-		incarnation:  0,
 		gossipPort:   gossipPort,
 		nReplicas:    replicationFactor,
+	}
+
+	return &Node{
+		kv:          store,
+		ring:        r,
+		gossipQueue: make([]*gossip.MessagePayload, 0),
+		peers:       make(map[string]peer.Peer),
+		incarnation: 0,
+		config:      config,
 	}
 }
 
@@ -63,7 +71,7 @@ func (n *Node) enqGossip(newMsg *gossip.MessagePayload) {
 			}
 		}
 	}
-	if len(newMsg.Peers) == 0 || len(n.gossipQueue) == n.maxGossipLen {
+	if len(newMsg.Peers) == 0 || len(n.gossipQueue) == n.config.maxGossipLen {
 		return
 	}
 	n.gossipQueue = append(n.gossipQueue, newMsg)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -26,11 +26,11 @@ type Node struct {
 }
 
 type NodeConfig struct {
-	maxGossipLen int
 	id           string
 	addr         string
-	nReplicas    int
 	gossipPort   string
+	maxGossipLen int
+	nReplicas    int
 }
 
 func NewNode(config *NodeConfig) *Node {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -33,15 +33,10 @@ type NodeConfig struct {
 	gossipPort   string
 }
 
-func NewNode(store *kv.Store, r *ring.HashRing, id string, addr string, gossipPort string, replicationFactor int) *Node {
-	config := &NodeConfig{
-		maxGossipLen: 50,
-		id:           id,
-		addr:         addr,
-		gossipPort:   gossipPort,
-		nReplicas:    replicationFactor,
-	}
-
+func NewNode(config *NodeConfig) *Node {
+	store := kv.NewStore(64 << 20) // 64MB default cap for MVP
+	r := ring.New(128, ring.FNV32a)
+	r.Add(config.id, config.addr)
 	return &Node{
 		kv:          store,
 		ring:        r,

--- a/pkg/node/replica_handlers.go
+++ b/pkg/node/replica_handlers.go
@@ -8,7 +8,7 @@ import (
 // putReplica writes the key/value pair to the local store (called by the primary).
 func (n *Node) PutReplica(w http.ResponseWriter, req *http.Request) {
 	key := req.URL.Path[len("/replica/"):]
-	slog.Info("[Writing Replica]", "url", req.URL.Path, "self id", n.addr)
+	slog.Info("[Writing Replica]", "url", req.URL.Path, "self id", n.config.addr)
 
 	body, err := readBody(req)
 	if err != nil {
@@ -28,7 +28,7 @@ func (n *Node) PutReplica(w http.ResponseWriter, req *http.Request) {
 
 func (n *Node) DelReplica(w http.ResponseWriter, req *http.Request) {
 	key := req.URL.Path[len("/replica/"):]
-	slog.Info("[Deleting Replica]", "url", req.URL.Path, "self id", n.addr)
+	slog.Info("[Deleting Replica]", "url", req.URL.Path, "self id", n.config.addr)
 	n.kv.Delete(key)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -106,16 +106,11 @@ func Config() *NodeConfig {
 
 // Generate node config from user input
 func ConfigWithOpts(id, addr, gossipPort string, nReplicas, gossipQueueLen int) *NodeConfig {
-	replicationFactor, err := strconv.Atoi(os.Getenv("REPLICATION_FACTOR"))
-	if err != nil {
-		slog.Warn("REPLICATION_FACTOR should be an int, could not parse, defaulting to 3")
-		replicationFactor = 3
-	}
 	return &NodeConfig{
 		maxGossipLen: gossipQueueLen,
 		id:           id,
 		addr:         addr,
-		nReplicas:    replicationFactor,
+		nReplicas:    nReplicas,
 		gossipPort:   gossipPort,
 	}
 }

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -85,7 +85,7 @@ func parseTTL(req *http.Request) (time.Duration, error) {
 	return time.Duration(sec) * time.Second, nil
 }
 
-// Generate node config from user input
+// Generate node config from environment variables
 func Config() *NodeConfig {
 	id := os.Getenv("SELF_ID")
 	addr := os.Getenv("SELF_ADDR")
@@ -104,7 +104,7 @@ func Config() *NodeConfig {
 	}
 }
 
-// Generate node config from user input
+// Generate node config, manual passing of configs for tests/benchmarks
 func ConfigWithOpts(id, addr, gossipPort string, nReplicas, gossipQueueLen int) *NodeConfig {
 	return &NodeConfig{
 		maxGossipLen: gossipQueueLen,

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -1,10 +1,13 @@
 package node
 
 import (
+	"cmp"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -80,4 +83,23 @@ func parseTTL(req *http.Request) (time.Duration, error) {
 		return 0, fmt.Errorf("invalid ttl")
 	}
 	return time.Duration(sec) * time.Second, nil
+}
+
+// Generate node config from user input
+func Config() *NodeConfig {
+	id := os.Getenv("SELF_ID")
+	addr := os.Getenv("SELF_ADDR")
+	gossipPort := cmp.Or(os.Getenv("GOSSIP_PORT"), "4000")
+	replicationFactor, err := strconv.Atoi(os.Getenv("REPLICATION_FACTOR"))
+	if err != nil {
+		slog.Warn("REPLICATION_FACTOR should be an int, could not parse, defaulting to 3")
+		replicationFactor = 3
+	}
+	return &NodeConfig{
+		maxGossipLen: 50,
+		id:           id,
+		addr:         addr,
+		nReplicas:    replicationFactor,
+		gossipPort:   gossipPort,
+	}
 }

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -103,3 +103,19 @@ func Config() *NodeConfig {
 		gossipPort:   gossipPort,
 	}
 }
+
+// Generate node config from user input
+func ConfigWithOpts(id, addr, gossipPort string, nReplicas, gossipQueueLen int) *NodeConfig {
+	replicationFactor, err := strconv.Atoi(os.Getenv("REPLICATION_FACTOR"))
+	if err != nil {
+		slog.Warn("REPLICATION_FACTOR should be an int, could not parse, defaulting to 3")
+		replicationFactor = 3
+	}
+	return &NodeConfig{
+		maxGossipLen: gossipQueueLen,
+		id:           id,
+		addr:         addr,
+		nReplicas:    replicationFactor,
+		gossipPort:   gossipPort,
+	}
+}

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -35,20 +35,20 @@ func OverrideHostPort(addr, port string) string {
 }
 
 // ownerForKey looks up the owner for a key and normalizes the address of the owner
-func (s *Node) OwnerForKey(key string) (ownerHP, selfHP string, ok bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	ownerID := s.ring.Lookup([]byte(key)) // e.g. "Node3"
-	ownerAddr, ok := s.ring.Addr(ownerID) // e.g. "Node3:8080" (what you stored)
+func (n *Node) OwnerForKey(key string) (ownerHP, selfHP string, ok bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	ownerID := n.ring.Lookup([]byte(key)) // e.g. "Node3"
+	ownerAddr, ok := n.ring.Addr(ownerID) // e.g. "Node3:8080" (what you stored)
 	if !ok || ownerAddr == "" {
 		return "", "", false
 	}
-	return NormalizeHostPort(ownerAddr, "8080"), NormalizeHostPort(s.addr, "8080"), true
+	return NormalizeHostPort(ownerAddr, "8080"), NormalizeHostPort(n.config.addr, "8080"), true
 }
 
 // replicas looks up the replicas for a key and normalizes their addresses
 func (n *Node) ReplicasForKey(key string) (replicaAddrs []string) {
-	replicaIds := n.ring.LookupN([]byte(key), n.nReplicas) // e.g. "Node3"
+	replicaIds := n.ring.LookupN([]byte(key), n.config.nReplicas) // e.g. "Node3"
 
 	addrs := make([]string, len(replicaIds))
 	for i := range len(replicaIds) {


### PR DESCRIPTION
This PR consolidates user provider configs in node by removing the individual fields from the `Node` struct and replacing them with a new `NodeConfig` struct.

This PR also separates servers for client facing endpoints (e.g. /healthz /info /kv) and peer facing endpoints (e.g. /replication), each using a distinct port.