### PR TITLE
TLS for replication traffic

### DIFF
--- a/cmd/gencerts/main.go
+++ b/cmd/gencerts/main.go
@@ -1,0 +1,87 @@
+// gencerts generates a CA and per-node TLS certificates for a ZephyrCache
+// cluster. Each node gets one cert used for both the replica (mTLS) and KV
+// (one-way TLS) endpoints.
+//
+// Usage:
+//
+//	gencerts [-out <dir>] [-nodes node0,node1,node2] [-hosts 127.0.0.1,localhost]
+//
+// Example — 3-node local cluster:
+//
+//	gencerts -out ./certs -nodes node0,node1,node2 -hosts 127.0.0.1
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ryandielhenn/zephyrcache/pkg/node"
+)
+
+func main() {
+	outDir := flag.String("out", "certs", "directory to write cert files into")
+	nodesFlag := flag.String("nodes", "node0,node1,node2", "comma-separated node IDs")
+	hostsFlag := flag.String("hosts", "127.0.0.1,localhost", "comma-separated IPs/hostnames to include in every cert SAN")
+	flag.Parse()
+
+	nodeIDs := splitTrim(*nodesFlag)
+	hosts := splitTrim(*hostsFlag)
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		log.Fatalf("create output dir: %v", err)
+	}
+
+	ca, err := node.GenerateCA()
+	if err != nil {
+		log.Fatalf("generate CA: %v", err)
+	}
+	write(*outDir, "ca.crt", ca.CertPEM)
+	write(*outDir, "ca.key", ca.KeyPEM)
+	fmt.Printf("wrote %s/ca.crt  %s/ca.key\n", *outDir, *outDir)
+
+	fmt.Println()
+	fmt.Println("Per-node environment variables:")
+	fmt.Println()
+
+	for _, id := range nodeIDs {
+		creds, err := node.GenerateNodeCert(ca, hosts)
+		if err != nil {
+			log.Fatalf("generate cert for %s: %v", id, err)
+		}
+		certFile := id + ".crt"
+		keyFile := id + ".key"
+		write(*outDir, certFile, creds.CertPEM)
+		write(*outDir, keyFile, creds.KeyPEM)
+
+		abs, _ := filepath.Abs(*outDir)
+		fmt.Printf("# %s\n", id)
+		fmt.Printf("export REPLICA_CA_FILE=%s/ca.crt\n", abs)
+		fmt.Printf("export REPLICA_CERT_FILE=%s/%s\n", abs, certFile)
+		fmt.Printf("export REPLICA_KEY_FILE=%s/%s\n", abs, keyFile)
+		fmt.Printf("export KV_CERT_FILE=%s/%s\n", abs, certFile)
+		fmt.Printf("export KV_KEY_FILE=%s/%s\n", abs, keyFile)
+		fmt.Println()
+	}
+}
+
+func write(dir, name string, data []byte) {
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		log.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func splitTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,9 @@ func main() {
 	})))
 	// 2. Connect to cluster
 	n := node.NewNode(node.Config())
+	if err := node.ConfigureTLS(n); err != nil {
+		log.Fatal(err)
+	}
 	switch membershipService {
 	case "etcd":
 		cleanup := n.JoinEtcd()
@@ -61,10 +64,18 @@ func main() {
 				}
 			})
 
-		peerFacingAddr := ":8081"
+		peerFacingAddr := ":443"
 		slog.Info("ZephyrCache node listening to peers on", "addr", peerFacingAddr)
-		if err := http.ListenAndServe(peerFacingAddr, peerMux); err != nil {
-			log.Fatal(err.Error())
+
+		srv := &http.Server{
+			Addr:      peerFacingAddr,
+			Handler:   peerMux,
+			TLSConfig: n.ServerTLSConfig(),
+		}
+		if n.ServerTLSConfig() != nil {
+			log.Fatal(srv.ListenAndServeTLS("", ""))
+		} else {
+			log.Fatal(srv.ListenAndServe())
 		}
 	}()
 
@@ -94,6 +105,7 @@ func main() {
 	clientFacingAddr := ":8080"
 	slog.Info("ZephyrCache node listening to clients on", "addr", clientFacingAddr)
 	if err := http.ListenAndServe(clientFacingAddr, clientMux); err != nil {
-		log.Fatal(err.Error())
+		slog.Error("ZephyrCache client api error", "err", err)
+
 	}
 }

--- a/pkg/node/gossip_handlers.go
+++ b/pkg/node/gossip_handlers.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ryandielhenn/zephyrcache/pkg/peer"
 )
 
+const GOSSIP_PORT_DEFAULT string = "4000"
+
 func (n *Node) handleGossip(msg *gossip.Message) {
 	if msg == nil {
 		return
@@ -49,6 +51,7 @@ func (n *Node) handlePing(msg *gossip.Message) {
 			Addr:        peerBody.Addr,
 			Status:      peer.Suspected,
 			Incarnation: peerBody.Incarnation,
+			GossipAddr:  peerBody.GossipAddr,
 		}
 	}
 	message := gossip.NewMessage(
@@ -58,7 +61,7 @@ func (n *Node) handlePing(msg *gossip.Message) {
 		msg.OriginId,
 		payload,
 	)
-	n.sendGossip(message, n.peerGossipAddr(peerBody))
+	n.sendGossip(message, peerBody.GossipAddr)
 }
 
 func (n *Node) handlePingReq(msg *gossip.Message) {
@@ -74,7 +77,7 @@ func (n *Node) handlePingReq(msg *gossip.Message) {
 		msg.OriginId,
 		payload,
 	)
-	n.sendGossip(message, n.peerGossipAddr(peerBody))
+	n.sendGossip(message, peerBody.GossipAddr)
 }
 
 func (n *Node) handlePingAck(msg *gossip.Message) {
@@ -103,7 +106,7 @@ func (n *Node) handlePingAck(msg *gossip.Message) {
 		msg.OriginId,
 		payload,
 	)
-	n.sendGossip(message, n.peerGossipAddr(peerBody))
+	n.sendGossip(message, peerBody.GossipAddr)
 }
 
 func (n *Node) handlePayload(msg *gossip.MessagePayload, sourceId string) {
@@ -224,13 +227,6 @@ func (n *Node) handleDeadStatus(id string, updatedPeer peer.Peer) {
 		payload := gossip.NewPayload(peers, true)
 		n.enqGossip(payload)
 	}
-}
-
-func (n *Node) peerGossipAddr(p peer.Peer) string {
-	if p.GossipAddr != "" {
-		return p.GossipAddr
-	}
-	return OverrideHostPort(p.Addr, n.config.gossipPort)
 }
 
 func (n *Node) selfGossipAddr() string {
@@ -414,7 +410,7 @@ func runGossipPing(node *Node, cfg *pingerConfig) {
 		node.config.id,
 		payload,
 	)
-	node.sendGossip(message, node.peerGossipAddr(peerBody))
+	node.sendGossip(message, peerBody.GossipAddr)
 
 	// send ping req to k random peers after timeout
 	targetPeer := node.targetPeer
@@ -438,7 +434,7 @@ func runGossipPing(node *Node, cfg *pingerConfig) {
 				node.config.id,
 				payload,
 			)
-			node.sendGossip(message, node.peerGossipAddr(peerBody))
+			node.sendGossip(message, peerBody.GossipAddr)
 		}
 	})
 }

--- a/pkg/node/gossip_handlers.go
+++ b/pkg/node/gossip_handlers.go
@@ -58,7 +58,7 @@ func (n *Node) handlePing(msg *gossip.Message) {
 		msg.OriginId,
 		payload,
 	)
-	n.sendGossip(message, peerBody.Addr)
+	n.sendGossip(message, n.peerGossipAddr(peerBody))
 }
 
 func (n *Node) handlePingReq(msg *gossip.Message) {
@@ -74,7 +74,7 @@ func (n *Node) handlePingReq(msg *gossip.Message) {
 		msg.OriginId,
 		payload,
 	)
-	n.sendGossip(message, peerBody.Addr)
+	n.sendGossip(message, n.peerGossipAddr(peerBody))
 }
 
 func (n *Node) handlePingAck(msg *gossip.Message) {
@@ -103,7 +103,7 @@ func (n *Node) handlePingAck(msg *gossip.Message) {
 		msg.OriginId,
 		payload,
 	)
-	n.sendGossip(message, peerBody.Addr)
+	n.sendGossip(message, n.peerGossipAddr(peerBody))
 }
 
 func (n *Node) handlePayload(msg *gossip.MessagePayload, sourceId string) {
@@ -138,6 +138,7 @@ func (n *Node) handleAliveStatus(id string, updatedPeer peer.Peer, sourceId stri
 		peers := n.getPeerMap()
 		peers[n.config.id] = peer.Peer{
 			Addr:        n.config.addr,
+			GossipAddr:  n.selfGossipAddr(),
 			Status:      peer.Alive,
 			Incarnation: n.incarnation,
 		}
@@ -169,6 +170,7 @@ func (n *Node) handleSuspectedStatus(id string, updatedPeer peer.Peer) {
 		peers := map[string]peer.Peer{
 			n.config.id: {
 				Addr:        n.config.addr,
+				GossipAddr:  n.selfGossipAddr(),
 				Status:      peer.Alive,
 				Incarnation: n.incarnation,
 			},
@@ -224,13 +226,24 @@ func (n *Node) handleDeadStatus(id string, updatedPeer peer.Peer) {
 	}
 }
 
+func (n *Node) peerGossipAddr(p peer.Peer) string {
+	if p.GossipAddr != "" {
+		return p.GossipAddr
+	}
+	return OverrideHostPort(p.Addr, n.config.gossipPort)
+}
+
+func (n *Node) selfGossipAddr() string {
+	return OverrideHostPort(n.config.addr, n.config.gossipPort)
+}
+
 func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return
 	}
 
-	udpAddr, err := net.ResolveUDPAddr("udp", OverrideHostPort(addr, n.config.gossipPort))
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return
 	}
@@ -258,6 +271,7 @@ func (n *Node) attemptConnectToCluster(addr string) bool {
 	peers := map[string]peer.Peer{
 		n.config.id: {
 			Addr:        n.config.addr,
+			GossipAddr:  n.selfGossipAddr(),
 			Status:      peer.Alive,
 			Incarnation: 0,
 		},
@@ -400,7 +414,7 @@ func runGossipPing(node *Node, cfg *pingerConfig) {
 		node.config.id,
 		payload,
 	)
-	node.sendGossip(message, peerBody.Addr)
+	node.sendGossip(message, node.peerGossipAddr(peerBody))
 
 	// send ping req to k random peers after timeout
 	targetPeer := node.targetPeer
@@ -424,7 +438,7 @@ func runGossipPing(node *Node, cfg *pingerConfig) {
 				node.config.id,
 				payload,
 			)
-			node.sendGossip(message, peerBody.Addr)
+			node.sendGossip(message, node.peerGossipAddr(peerBody))
 		}
 	})
 }

--- a/pkg/node/http_handlers.go
+++ b/pkg/node/http_handlers.go
@@ -35,6 +35,13 @@ func (n *Node) Info(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
+func (n *Node) replicaScheme() string {
+	if n.serverTLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
 // forward forwards a http request to the Node that owns the key
 func (n *Node) Forward(w http.ResponseWriter, req *http.Request, owner string) {
 	if owner == "" {
@@ -49,7 +56,7 @@ func (n *Node) Forward(w http.ResponseWriter, req *http.Request, owner string) {
 		return
 	}
 	target := *req.URL
-	target.Scheme = "http"
+	target.Scheme = n.replicaScheme()
 	target.Host = hostport
 
 	out, err := http.NewRequestWithContext(req.Context(), req.Method, target.String(), req.Body)
@@ -62,7 +69,7 @@ func (n *Node) Forward(w http.ResponseWriter, req *http.Request, owner string) {
 
 	out.Header.Set("X-Forwarded-For", req.RemoteAddr)
 
-	resp, err := http.DefaultClient.Do(out)
+	resp, err := n.replicaClient.Do(out)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -114,7 +121,7 @@ func (n *Node) Put(w http.ResponseWriter, req *http.Request) {
 				n.kv.Put(key, body, ttl)
 			} else {
 				slog.Info("[Forward PUT]", "key", key, "replica", repAddr, "self", selfAddr)
-				replicaURL := "http://" + repAddr + "/replica/" + key
+				replicaURL := n.replicaScheme() + "://" + repAddr + "/replica/" + key
 				if q := req.URL.RawQuery; q != "" {
 					replicaURL += "?" + q
 				}
@@ -123,7 +130,7 @@ func (n *Node) Put(w http.ResponseWriter, req *http.Request) {
 					slog.Warn("error building replication request", "err", err)
 					return
 				}
-				resp, err := http.DefaultClient.Do(repReq)
+				resp, err := n.replicaClient.Do(repReq)
 				if err != nil {
 					slog.Warn("error forwarding to replica", "err", err, "replica", repAddr)
 					return
@@ -192,14 +199,14 @@ func (n *Node) Del(w http.ResponseWriter, req *http.Request) {
 				n.kv.Delete(key)
 			} else {
 				slog.Info("[Forward DEL]", "key", key, "replica", repAddr, "self", selfAddr)
-				replicaURL := "http://" + repAddr + "/replica/" + key
+				replicaURL := n.replicaScheme() + "://" + repAddr + "/replica/" + key
 
 				repReq, err := http.NewRequestWithContext(req.Context(), http.MethodDelete, replicaURL, bytes.NewReader(body))
 				if err != nil {
 					slog.Warn("error building delete replica request", "err", err)
 					return
 				}
-				resp, err := http.DefaultClient.Do(repReq)
+				resp, err := n.replicaClient.Do(repReq)
 				if err != nil {
 					slog.Warn("error forwarding delete to replica", "err", err, "replica", repAddr)
 					return

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1,9 +1,11 @@
 package node
 
 import (
+	"crypto/tls"
 	"log/slog"
 	"math"
 	"math/rand"
+	"net/http"
 	"sync"
 	"time"
 
@@ -14,15 +16,17 @@ import (
 )
 
 type Node struct {
-	kv          *kv.Store
-	ring        *ring.HashRing
-	gossipQueue []*gossip.MessagePayload
-	peers       map[string]peer.Peer
-	incarnation int
-	targetPeer  string
-	timeout     *time.Timer
-	mu          sync.Mutex
-	config      *NodeConfig
+	kv            *kv.Store
+	ring          *ring.HashRing
+	gossipQueue   []*gossip.MessagePayload
+	peers         map[string]peer.Peer
+	incarnation   int
+	targetPeer    string
+	timeout       *time.Timer
+	mu            sync.Mutex
+	config        *NodeConfig
+	serverTLS     *tls.Config
+	replicaClient *http.Client
 }
 
 type NodeConfig struct {
@@ -38,13 +42,36 @@ func NewNode(config *NodeConfig) *Node {
 	r := ring.New(128, ring.FNV32a)
 	r.Add(config.id, config.addr)
 	return &Node{
-		kv:          store,
-		ring:        r,
-		gossipQueue: make([]*gossip.MessagePayload, 0),
-		peers:       make(map[string]peer.Peer),
-		incarnation: 0,
-		config:      config,
+		kv:            store,
+		ring:          r,
+		gossipQueue:   make([]*gossip.MessagePayload, 0),
+		peers:         make(map[string]peer.Peer),
+		incarnation:   0,
+		config:        config,
+		replicaClient: http.DefaultClient,
 	}
+}
+
+// SetReplicaTLS configures mutual TLS for the replication endpoint.
+// serverTLS is used by the replication HTTPS server; clientTLS is used
+// when this node calls replicas.
+func (n *Node) SetReplicaTLS(serverTLS, clientTLS *tls.Config) {
+	n.serverTLS = serverTLS
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = clientTLS
+	n.replicaClient = &http.Client{Transport: t}
+}
+
+// ServerTLSConfig returns the TLS config for the replication server,
+// or nil when TLS is not configured.
+func (n *Node) ServerTLSConfig() *tls.Config {
+	return n.serverTLS
+}
+
+// LocalGet reads a key directly from this node's local KV store,
+// bypassing ring-based forwarding. Intended for testing replica state.
+func (n *Node) LocalGet(key string) ([]byte, bool) {
+	return n.kv.Get(key)
 }
 
 func (n *Node) enqGossip(newMsg *gossip.MessagePayload) {

--- a/pkg/node/replication_test.go
+++ b/pkg/node/replication_test.go
@@ -1,0 +1,306 @@
+package node
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// tlsNode is a test node that serves /kv/ and /replica/ over HTTPS.
+type tlsNode struct {
+	n       *Node
+	id      string
+	addr    string // host:port of the HTTPS server
+	cleanup func()
+}
+
+// newTLSNode starts a node whose replication endpoint uses mTLS.
+// ca is the shared cluster CA; hosts is the list of IPs/hostnames the node's
+// cert should be valid for (typically []string{"127.0.0.1"}).
+func newTLSNode(t *testing.T, id string, ca *CA, hosts []string, nReplicas int, seedGossipAddr string) tlsNode {
+	t.Helper()
+
+	creds, err := GenerateNodeCert(ca, hosts)
+	if err != nil {
+		t.Fatalf("GenerateNodeCert: %v", err)
+	}
+	serverTLS, err := ServerTLSConfig(ca.CertPEM, creds)
+	if err != nil {
+		t.Fatalf("ServerTLSConfig: %v", err)
+	}
+	clientTLS, err := ClientTLSConfig(ca.CertPEM, creds)
+	if err != nil {
+		t.Fatalf("ClientTLSConfig: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	// Claim a random UDP port, note it, release it, then let StartGossipListener
+	// bind to it. The window between Close and ListenUDP is negligible in tests.
+	uconn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("udp listen: %v", err)
+	}
+	gossipPort := strconv.Itoa(uconn.LocalAddr().(*net.UDPAddr).Port)
+	gossipAddr := uconn.LocalAddr().String()
+	_ = uconn.Close()
+
+	cfg := ConfigWithOpts(id, addr, gossipPort, nReplicas, 50)
+	n := NewNode(cfg)
+	n.SetReplicaTLS(serverTLS, clientTLS)
+
+	go StartGossipListener(n)
+	go StartGossipPinger(n,
+		WithPeriod(50*time.Millisecond),
+		WithPingTimeout(50*time.Millisecond),
+		WithSuspectedTimeout(150*time.Millisecond),
+	)
+	if seedGossipAddr != "" {
+		go n.ConnectToCluster(seedGossipAddr, 50*time.Millisecond)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/kv/", func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodPut, http.MethodPost:
+			n.Put(w, req)
+		case http.MethodGet:
+			n.Get(w, req)
+		case http.MethodDelete:
+			n.Del(w, req)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/replica/", func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodPut, http.MethodPost:
+			n.PutReplica(w, req)
+		case http.MethodDelete:
+			n.DelReplica(w, req)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	srv := &http.Server{Handler: mux}
+	go func() {
+		if err := srv.Serve(tls.NewListener(ln, serverTLS)); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Info("test TLS server error", "node", id, "err", err)
+		}
+	}()
+
+	return tlsNode{
+		n:       n,
+		id:      id,
+		addr:    gossipAddr,
+		cleanup: func() { _ = srv.Close() },
+	}
+}
+
+// newClusterClient returns an HTTPS client that trusts the given CA and
+// presents the given node credentials.
+func newClusterClient(t *testing.T, ca *CA, creds *NodeTLSCreds) *http.Client {
+	t.Helper()
+	clientTLS, err := ClientTLSConfig(ca.CertPEM, creds)
+	if err != nil {
+		t.Fatalf("ClientTLSConfig: %v", err)
+	}
+	return &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: clientTLS},
+	}
+}
+
+// waitConverged blocks until every node in the cluster sees all peers as alive.
+func waitConverged(t *testing.T, nodes []tlsNode, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ok := true
+		for _, nd := range nodes {
+			nd.n.mu.Lock()
+			alive := nd.n.countPeers()
+			nd.n.mu.Unlock()
+			if alive < len(nodes)-1 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("cluster did not converge within", timeout)
+}
+
+func TestReplicationPut(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	const numNodes = 3
+	nodes := make([]tlsNode, numNodes)
+	nodes[0] = newTLSNode(t, "node0", ca, []string{"127.0.0.1"}, numNodes, "")
+	for i := 1; i < numNodes; i++ {
+		nodes[i] = newTLSNode(t, fmt.Sprintf("node%d", i), ca, []string{"127.0.0.1"}, numNodes, nodes[0].addr)
+	}
+	t.Cleanup(func() {
+		for _, nd := range nodes {
+			nd.cleanup()
+		}
+	})
+
+	waitConverged(t, nodes, 3*time.Second)
+
+	clientCreds, err := GenerateNodeCert(ca, []string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("GenerateNodeCert for client: %v", err)
+	}
+	client := newClusterClient(t, ca, clientCreds)
+
+	key := "hello"
+	value := []byte("world")
+
+	// PUT via node 0's HTTPS endpoint.
+	url := "https://" + nodes[0].n.config.addr + "/kv/" + key
+	resp, err := client.Post(url, "application/octet-stream", bytes.NewReader(value))
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("PUT status = %d, want 204", resp.StatusCode)
+	}
+
+	// Give async replication a moment to land.
+	time.Sleep(100 * time.Millisecond)
+
+	// Every node should have the key in its local store.
+	for i, nd := range nodes {
+		got, ok := nd.n.LocalGet(key)
+		if !ok {
+			t.Errorf("node%d: key %q not found after replication", i, key)
+			continue
+		}
+		if !bytes.Equal(got, value) {
+			t.Errorf("node%d: got %q, want %q", i, got, value)
+		}
+	}
+}
+
+func TestReplicationDelete(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	const numNodes = 3
+	nodes := make([]tlsNode, numNodes)
+	nodes[0] = newTLSNode(t, "node0", ca, []string{"127.0.0.1"}, numNodes, "")
+	for i := 1; i < numNodes; i++ {
+		nodes[i] = newTLSNode(t, fmt.Sprintf("node%d", i), ca, []string{"127.0.0.1"}, numNodes, nodes[0].addr)
+	}
+	t.Cleanup(func() {
+		for _, nd := range nodes {
+			nd.cleanup()
+		}
+	})
+
+	waitConverged(t, nodes, 3*time.Second)
+
+	clientCreds, err := GenerateNodeCert(ca, []string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("GenerateNodeCert for client: %v", err)
+	}
+	client := newClusterClient(t, ca, clientCreds)
+
+	key := "todelete"
+	value := []byte("temporary")
+	url := "https://" + nodes[0].n.config.addr + "/kv/" + key
+
+	// PUT first, wait for replication.
+	resp, err := client.Post(url, "application/octet-stream", bytes.NewReader(value))
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	_ = resp.Body.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// DELETE via node 0.
+	req, _ := http.NewRequest(http.MethodDelete, url, nil)
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204", resp.StatusCode)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// The key should be absent on every node.
+	for i, nd := range nodes {
+		if _, ok := nd.n.LocalGet(key); ok {
+			t.Errorf("node%d: key %q still present after delete replication", i, key)
+		}
+	}
+}
+
+func TestMTLSRejectsUnknownClient(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ca, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	nd := newTLSNode(t, "node0", ca, []string{"127.0.0.1"}, 1, "")
+	t.Cleanup(nd.cleanup)
+
+	// Build a rogue CA and present a cert signed by it — the server must reject it.
+	rogueCA, err := GenerateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA (rogue): %v", err)
+	}
+	rogueCreds, err := GenerateNodeCert(rogueCA, []string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("GenerateNodeCert (rogue): %v", err)
+	}
+	// Client trusts the real CA (so it accepts the server cert) but presents a
+	// rogue cert — the server should reject it at the TLS handshake.
+	rogueTLS, err := ClientTLSConfig(ca.CertPEM, rogueCreds)
+	if err != nil {
+		t.Fatalf("ClientTLSConfig (rogue): %v", err)
+	}
+	rogueClient := &http.Client{
+		Timeout:   3 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: rogueTLS},
+	}
+
+	url := "https://" + nd.n.config.addr + "/replica/testkey"
+	req, _ := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte("val")))
+	_, err = rogueClient.Do(req)
+	if err == nil {
+		t.Fatal("expected TLS error for rogue client, got nil")
+	}
+}

--- a/pkg/node/tls.go
+++ b/pkg/node/tls.go
@@ -1,0 +1,170 @@
+package node
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+// CA holds a generated certificate authority's PEM-encoded cert/key and
+// the parsed objects needed to sign node certificates.
+type CA struct {
+	CertPEM []byte
+	KeyPEM  []byte
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+}
+
+// NodeTLSCreds holds a node's PEM-encoded certificate and private key,
+// both signed by a CA.
+type NodeTLSCreds struct {
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+// GenerateCA creates a self-signed certificate authority.
+func GenerateCA() (*CA, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "ZephyrCache CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, err
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return &CA{
+		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		KeyPEM:  pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+		cert:    cert,
+		key:     key,
+	}, nil
+}
+
+// GenerateNodeCert creates a certificate signed by ca valid for the given hosts
+// (IP addresses or DNS names).
+func GenerateNodeCert(ca *CA, hosts []string) (*NodeTLSCreds, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "ZephyrCache Node"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		return nil, err
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return &NodeTLSCreds{
+		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		KeyPEM:  pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	}, nil
+}
+
+// ServerTLSConfig returns a *tls.Config for the replication HTTPS server.
+// It requires and verifies client certificates signed by caPEM (mTLS).
+func ServerTLSConfig(caPEM []byte, creds *NodeTLSCreds) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(creds.CertPEM, creds.KeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caPEM)
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    pool,
+		MinVersion:   tls.VersionTLS13,
+	}, nil
+}
+
+// ClientTLSConfig returns a *tls.Config for outgoing replication HTTPS calls.
+// It presents the node's own certificate and trusts only caPEM.
+func ClientTLSConfig(caPEM []byte, creds *NodeTLSCreds) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(creds.CertPEM, creds.KeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caPEM)
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS13,
+	}, nil
+}
+
+// configureTLS reads REPLICA_CERT_FILE, REPLICA_KEY_FILE, and REPLICA_CA_FILE
+// from the environment and, when all three are set, enables mTLS for the
+// replication endpoint. If none are set the node runs without TLS.
+func ConfigureTLS(n *Node) error {
+	certFile := os.Getenv("REPLICA_CERT_FILE")
+	keyFile := os.Getenv("REPLICA_KEY_FILE")
+	caFile := os.Getenv("REPLICA_CA_FILE")
+	if certFile == "" && keyFile == "" && caFile == "" {
+		return nil
+	}
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return err
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return err
+	}
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return err
+	}
+	creds := &NodeTLSCreds{CertPEM: certPEM, KeyPEM: keyPEM}
+	serverTLS, err := ServerTLSConfig(caPEM, creds)
+	if err != nil {
+		return err
+	}
+	clientTLS, err := ClientTLSConfig(caPEM, creds)
+	if err != nil {
+		return err
+	}
+	n.SetReplicaTLS(serverTLS, clientTLS)
+	return nil
+}

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -89,7 +89,7 @@ func parseTTL(req *http.Request) (time.Duration, error) {
 func Config() *NodeConfig {
 	id := os.Getenv("SELF_ID")
 	addr := os.Getenv("SELF_ADDR")
-	gossipPort := cmp.Or(os.Getenv("GOSSIP_PORT"), "4000")
+	gossipPort := cmp.Or(os.Getenv("GOSSIP_PORT"), GOSSIP_PORT_DEFAULT)
 	replicationFactor, err := strconv.Atoi(os.Getenv("REPLICATION_FACTOR"))
 	if err != nil {
 		slog.Warn("REPLICATION_FACTOR should be an int, could not parse, defaulting to 3")

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -2,6 +2,7 @@ package peer
 
 type Peer struct {
 	Addr        string     `json:"addr"`
+	GossipAddr  string     `json:"gossip_addr,omitempty"`
 	Status      PeerStatus `json:"status"`
 	Incarnation int        `json:"incarnation"`
 }

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -2,7 +2,7 @@ package peer
 
 type Peer struct {
 	Addr        string     `json:"addr"`
-	GossipAddr  string     `json:"gossip_addr,omitempty"`
+	GossipAddr  string     `json:"gossip_addr"`
 	Status      PeerStatus `json:"status"`
 	Incarnation int        `json:"incarnation"`
 }


### PR DESCRIPTION
Additions:

`node/tls.go` - functions for generating tls certs, ca, and configs.
`cmd/gencerts.go` - command line utility for generating certs.
`node/replication_test.go` - tests for put/delete with replication and tls.

Fixes: #25 