### PR TITLE
unresponsive cluster bug fixes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,33 +60,10 @@ func main() {
 	// 3. Wire up node facing endpoints
 	go func() {
 		peerMux := http.NewServeMux()
-		peerMux.HandleFunc("/replica/",
-			func(w http.ResponseWriter, req *http.Request) {
-				slog.Info("Received HTTP Replica Request", "type", req.Method)
-				switch req.Method {
-				case http.MethodPut, http.MethodPost:
-					n.PutReplica(w, req)
-				case http.MethodDelete:
-					n.DelReplica(w, req)
-				default:
-					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-				}
-			})
+		peerMux.HandleFunc("/replica/", n.ReplicaEventCallback())
 		// /kv/ also lives on the peer mux so inter-node forwards reuse the
 		// same (optionally TLS) channel as /replica/.
-		peerMux.HandleFunc("/kv/",
-			func(w http.ResponseWriter, req *http.Request) {
-				switch req.Method {
-				case http.MethodPut, http.MethodPost:
-					n.Put(w, req)
-				case http.MethodGet:
-					n.Get(w, req)
-				case http.MethodDelete:
-					n.Del(w, req)
-				default:
-					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-				}
-			})
+		peerMux.HandleFunc("/kv/", n.KvEventCallback())
 
 		peerFacingAddr := ":443"
 		slog.Info("ZephyrCache node listening to peers on", "addr", peerFacingAddr)
@@ -111,20 +88,7 @@ func main() {
 	clientMux.HandleFunc("/kv/",
 		func(w http.ResponseWriter, req *http.Request) {
 			op := strings.ToLower(req.Method)
-			telemetry.Instrument(op, http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					slog.Info("Received HTTP KV Request", "type", r.Method)
-					switch r.Method {
-					case http.MethodPut, http.MethodPost:
-						n.Put(w, r)
-					case http.MethodGet:
-						n.Get(w, r)
-					case http.MethodDelete:
-						n.Del(w, r)
-					default:
-						http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-					}
-				})).ServeHTTP(w, req)
+			telemetry.Instrument(op, http.HandlerFunc(n.KvEventCallback())).ServeHTTP(w, req)
 		})
 	clientFacingAddr := ":8080"
 	slog.Info("ZephyrCache node listening to clients on", "addr", clientFacingAddr)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -72,6 +72,21 @@ func main() {
 					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 				}
 			})
+		// /kv/ also lives on the peer mux so inter-node forwards reuse the
+		// same (optionally TLS) channel as /replica/.
+		peerMux.HandleFunc("/kv/",
+			func(w http.ResponseWriter, req *http.Request) {
+				switch req.Method {
+				case http.MethodPut, http.MethodPost:
+					n.Put(w, req)
+				case http.MethodGet:
+					n.Get(w, req)
+				case http.MethodDelete:
+					n.Del(w, req)
+				default:
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				}
+			})
 
 		peerFacingAddr := ":443"
 		slog.Info("ZephyrCache node listening to peers on", "addr", peerFacingAddr)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,10 @@ if [ -z "$SELF_ID" ]; then
     export SELF_ID="$CONTAINER_HOSTNAME"
 fi
 
-# Set SELF_ADDR if not already set
+# Set SELF_ADDR if not already set. Points at the peer port (:443) where
+# /replica/ and inter-node /kv/ are served — clients still reach /kv/ on :8080.
 if [ -z "$SELF_ADDR" ]; then
-    export SELF_ADDR="http://$CONTAINER_HOSTNAME:8080"
+    export SELF_ADDR="$CONTAINER_HOSTNAME:443"
 fi
 
 echo "Starting node with:"

--- a/pkg/node/gossip_handlers.go
+++ b/pkg/node/gossip_handlers.go
@@ -14,6 +14,7 @@ import (
 )
 
 const GOSSIP_PORT_DEFAULT string = "4000"
+const PEER_PORT_DEFAULT string = "443"
 
 func (n *Node) handleGossip(msg *gossip.Message) {
 	if msg == nil {
@@ -239,6 +240,7 @@ func (n *Node) selfGossipAddr() string {
 func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 	data, err := json.Marshal(msg)
 	if err != nil {
+		slog.Error("sendGossip marshal failed", "addr", addr, "err", err)
 		return
 	}
 
@@ -246,6 +248,7 @@ func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 	if !ok {
 		udpAddr, err := net.ResolveUDPAddr("udp", addr)
 		if err != nil {
+			slog.Error("sendGossip resolve failed", "addr", addr, "err", err)
 			return
 		}
 
@@ -257,6 +260,7 @@ func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 				dtls.WithRootCAs(n.serverTLS.ClientCAs),
 			)
 			if err != nil {
+				slog.Error("sendGossip dial (mTLS) failed", "addr", addr, "err", err)
 				return
 			}
 			conn = secureConn
@@ -268,9 +272,11 @@ func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 				dtls.WithPSK(func(hint []byte) ([]byte, error) {
 					return []byte("secret-key"), nil
 				}),
+				dtls.WithPSKIdentityHint([]byte("zephyr")),
 				dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM),
 			)
 			if err != nil {
+				slog.Error("sendGossip dial (PSK) failed", "addr", addr, "err", err)
 				return
 			}
 			conn = insecureConn
@@ -281,6 +287,7 @@ func (n *Node) sendGossip(msg *gossip.Message, addr string) {
 
 	_, err = conn.Write(data)
 	if err != nil {
+		slog.Error("sendGossip write failed", "addr", addr, "err", err)
 		delete(n.dtlsConns, addr)
 		_ = conn.Close()
 		return
@@ -354,9 +361,11 @@ func StartGossipListener(ctx context.Context, node *Node) {
 			dtls.WithPSK(func(hint []byte) ([]byte, error) {
 				return []byte("secret-key"), nil
 			}),
+			dtls.WithPSKIdentityHint([]byte("zephyr")),
 			dtls.WithCipherSuites(dtls.TLS_PSK_WITH_AES_128_CCM),
 		)
 		if err != nil {
+			slog.Error("gossip listener (PSK) failed", "err", err)
 			return
 		}
 		ln = insecureLn
@@ -374,6 +383,7 @@ func StartGossipListener(ctx context.Context, node *Node) {
 			case <-ctx.Done():
 				return
 			default:
+				slog.Error("gossip listener accept failed", "err", err)
 				continue
 			}
 		}

--- a/pkg/node/http_handlers.go
+++ b/pkg/node/http_handlers.go
@@ -49,8 +49,8 @@ func (n *Node) Forward(w http.ResponseWriter, req *http.Request, owner string) {
 		return
 	}
 
-	hostport := NormalizeHostPort(owner, "8080")
-	if NormalizeHostPort(n.config.addr, "8080") == hostport {
+	hostport := NormalizeHostPort(owner, PEER_PORT_DEFAULT)
+	if NormalizeHostPort(n.config.addr, PEER_PORT_DEFAULT) == hostport {
 		// last-resort safety; shouldn’t happen if handler compare is correct
 		http.Error(w, "refusing to forward to self", http.StatusInternalServerError)
 		return
@@ -110,7 +110,7 @@ func (n *Node) Put(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	selfAddr := NormalizeHostPort(n.config.addr, "8080")
+	selfAddr := NormalizeHostPort(n.config.addr, PEER_PORT_DEFAULT)
 	var wg sync.WaitGroup
 	for _, repAddr := range replicaAddrs {
 		wg.Add(1)
@@ -187,7 +187,7 @@ func (n *Node) Del(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	selfAddr := NormalizeHostPort(n.config.addr, "8080")
+	selfAddr := NormalizeHostPort(n.config.addr, PEER_PORT_DEFAULT)
 	var wg sync.WaitGroup
 	for _, addr := range replicaAddrs {
 		wg.Add(1)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -56,6 +56,36 @@ func NewNode(config *NodeConfig) *Node {
 	}
 }
 
+func (n *Node) KvEventCallback() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slog.Info("Received HTTP KV Request", "type", r.Method)
+		switch r.Method {
+		case http.MethodPut, http.MethodPost:
+			n.Put(w, r)
+		case http.MethodGet:
+			n.Get(w, r)
+		case http.MethodDelete:
+			n.Del(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func (n *Node) ReplicaEventCallback() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		slog.Info("Received HTTP Replica Request", "type", req.Method)
+		switch req.Method {
+		case http.MethodPut, http.MethodPost:
+			n.PutReplica(w, req)
+		case http.MethodDelete:
+			n.DelReplica(w, req)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
 // SetReplicaTLS configures mutual TLS for the replication endpoint.
 // serverTLS is used by the replication HTTPS server; clientTLS is used
 // when this node calls replicas.

--- a/pkg/node/utils.go
+++ b/pkg/node/utils.go
@@ -30,6 +30,12 @@ func NormalizeHostPort(addr, defPort string) string {
 }
 
 func OverrideHostPort(addr, port string) string {
+	if rest, ok := strings.CutPrefix(addr, "http://"); ok {
+		addr = rest
+	} else if rest, ok := strings.CutPrefix(addr, "https://"); ok {
+		addr = rest
+	}
+
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return addr + ":" + port
@@ -46,7 +52,7 @@ func (n *Node) OwnerForKey(key string) (ownerHP, selfHP string, ok bool) {
 	if !ok || ownerAddr == "" {
 		return "", "", false
 	}
-	return NormalizeHostPort(ownerAddr, "8080"), NormalizeHostPort(n.config.addr, "8080"), true
+	return NormalizeHostPort(ownerAddr, PEER_PORT_DEFAULT), NormalizeHostPort(n.config.addr, PEER_PORT_DEFAULT), true
 }
 
 // replicas looks up the replicas for a key and normalizes their addresses
@@ -59,7 +65,7 @@ func (n *Node) ReplicasForKey(key string) (replicaAddrs []string) {
 		if !ok || addr == "" {
 			return nil
 		}
-		addrs[i] = NormalizeHostPort(addr, "8080")
+		addrs[i] = NormalizeHostPort(addr, PEER_PORT_DEFAULT)
 
 	}
 	return addrs


### PR DESCRIPTION
Several bugs were leading to an unresponsive cluster including improper ports for inter-node and client-node communication, quirk in dtls library requires PSK hint, and address prefix not being properly stripped in `OverrideHostPort`.

All tests now pass and PUTS/GETS, forwards, and replication  all work.