### PR TITLE
wire tls into docker compose and fix monitoring setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMPOSE   := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy
 ifeq ($(TLS),1)
 COMPOSE   += -f deploy/docker-compose.tls.yml
 endif
-ALL := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy/docker-compose.etcd.yml -f deploy/docker-compose.gossip.yml -f deploy/docker-compose.tls.yml
+ALL := docker compose -p $(PROJECT) -f deploy/monitoring/docker-compose.yml -f deploy/docker-compose.yml -f deploy/docker-compose.etcd.yml -f deploy/docker-compose.gossip.yml -f deploy/docker-compose.tls.yml
 
 # Extra SANs on the cluster cert. Internal peer traffic pins ServerName to
 # zephyr-cluster (auto-added by GenerateNodeCert), so these are only needed for
@@ -39,6 +39,10 @@ certs:
 	@mkdir -p certs
 	go run ./cmd/gencerts -out ./certs -nodes cluster -hosts $(CERT_HOSTS)
 	@echo "wrote certs for hosts: $(CERT_HOSTS)"
+
+## monitor: bring up prometheus + grafana attached to the cluster network
+monitor:
+	docker compose -p $(PROJECT) -f deploy/monitoring/docker-compose.yml up -d
 
 ## down: stop and remove containers
 down:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMPOSE   := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy
 ifeq ($(TLS),1)
 COMPOSE   += -f deploy/docker-compose.tls.yml
 endif
-ALL := docker compose -p $(PROJECT) -f deploy/monitoring/docker-compose.yml -f deploy/docker-compose.yml -f deploy/docker-compose.etcd.yml -f deploy/docker-compose.gossip.yml -f deploy/docker-compose.tls.yml
+ALL := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy/docker-compose.etcd.yml -f deploy/docker-compose.gossip.yml -f deploy/docker-compose.tls.yml
 
 # Extra SANs on the cluster cert. Internal peer traffic pins ServerName to
 # zephyr-cluster (auto-added by GenerateNodeCert), so these are only needed for
@@ -43,6 +43,8 @@ certs:
 ## monitor: bring up prometheus + grafana attached to the cluster network
 monitor:
 	docker compose -p $(PROJECT) -f deploy/monitoring/docker-compose.yml up -d
+monitor-down:
+	docker compose -p $(PROJECT) -f deploy/monitoring/docker-compose.yml down
 
 ## down: stop and remove containers
 down:

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,34 @@
 
 DISCOVERY ?= gossip
 NODES     ?= 3
+TLS       ?= 0
 PROJECT   := zephyr
 COMPOSE   := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy/docker-compose.$(DISCOVERY).yml
-ALL := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy/docker-compose.etcd.yml -f deploy/docker-compose.gossip.yml
+ifeq ($(TLS),1)
+COMPOSE   += -f deploy/docker-compose.tls.yml
+endif
+ALL := docker compose -p $(PROJECT) -f deploy/docker-compose.yml -f deploy/docker-compose.etcd.yml -f deploy/docker-compose.gossip.yml -f deploy/docker-compose.tls.yml
 
-.PHONY: up down restart build logs status clean ps
+# Extra SANs on the cluster cert. Internal peer traffic pins ServerName to
+# zephyr-cluster (auto-added by GenerateNodeCert), so these are only needed for
+# ad-hoc debugging like `curl --cacert ca.crt https://127.0.0.1:443/...`.
+CERT_HOSTS := 127.0.0.1,localhost
+
+.PHONY: up down restart build logs status clean ps certs
 
 ## seed: start seed node
 seed: build
 	$(COMPOSE) up -d seed
 
 ## up: scale peers
-up: build
+up: build $(if $(filter 1,$(TLS)),certs)
 	$(COMPOSE) up -d --scale node=$(NODES)
+
+## certs: generate a shared CA + cluster cert under ./certs
+certs:
+	@mkdir -p certs
+	go run ./cmd/gencerts -out ./certs -nodes cluster -hosts $(CERT_HOSTS)
+	@echo "wrote certs for hosts: $(CERT_HOSTS)"
 
 ## down: stop and remove containers
 down:

--- a/deploy/docker-compose.gossip.yml
+++ b/deploy/docker-compose.gossip.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
+      network: host
     environment:
       - DISCOVERY=gossip
       - SELF_ID=seed

--- a/deploy/docker-compose.tls.yml
+++ b/deploy/docker-compose.tls.yml
@@ -1,0 +1,16 @@
+services:
+  seed:
+    volumes:
+      - ../certs:/certs:ro
+    environment:
+      - REPLICA_CA_FILE=/certs/ca.crt
+      - REPLICA_CERT_FILE=/certs/cluster.crt
+      - REPLICA_KEY_FILE=/certs/cluster.key
+
+  node:
+    volumes:
+      - ../certs:/certs:ro
+    environment:
+      - REPLICA_CA_FILE=/certs/ca.crt
+      - REPLICA_CERT_FILE=/certs/cluster.crt
+      - REPLICA_KEY_FILE=/certs/cluster.key

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
+      network: host
     environment:
       - LOG_LEVEL=info
     ports:

--- a/deploy/monitoring/docker-compose.yml
+++ b/deploy/monitoring/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
   prometheus:
     image: prom/prometheus:latest
+    user: root
     command:
       - --config.file=/etc/prometheus/prometheus.yml
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
       - "9090:9090"
     restart: unless-stopped

--- a/deploy/monitoring/docker-compose.yml
+++ b/deploy/monitoring/docker-compose.yml
@@ -23,6 +23,9 @@ services:
     restart: unless-stopped
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      # Dashboard JSON files; the provisioning provider scans this directory.
+      - ./grafana:/var/lib/grafana/dashboards:ro
     networks:
       - cluster
 

--- a/deploy/monitoring/docker-compose.yml
+++ b/deploy/monitoring/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "9090:9090"
     restart: unless-stopped
+    networks:
+      - cluster
 
   grafana:
     image: grafana/grafana-oss:latest
@@ -21,5 +23,15 @@ services:
     restart: unless-stopped
     volumes:
       - grafana-data:/var/lib/grafana
+    networks:
+      - cluster
+
 volumes:
   grafana-data:
+
+# Reuses the network created by the cluster compose project (`make up`),
+# so prometheus can resolve `seed` and `node` directly via Docker DNS.
+networks:
+  cluster:
+    name: zephyr_default
+    external: true

--- a/deploy/monitoring/grafana/provisioning/dashboards/zephyrcache.yml
+++ b/deploy/monitoring/grafana/provisioning/dashboards/zephyrcache.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: zephyrcache
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    # Pinned to match the datasource UID hardcoded in dashboard JSON files.
+    uid: aevxy37uxd14wd

--- a/deploy/monitoring/grafana/zephyrcache-metrics.json
+++ b/deploy/monitoring/grafana/zephyrcache-metrics.json
@@ -198,7 +198,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "up{job=\"zephyrcache\"}",
+          "expr": "up{job=~\"zephyrcache-.*\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/deploy/monitoring/grafana/zephyrcache-metrics.json
+++ b/deploy/monitoring/grafana/zephyrcache-metrics.json
@@ -307,6 +307,151 @@
       ],
       "title": "Total Requests",
       "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "aevxy37uxd14wd"},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {"0": {"text": "No", "color": "red"}, "1": {"text": "Yes", "color": "green"}}}
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red"},
+              {"color": "green", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value"
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "aevxy37uxd14wd"},
+          "editorMode": "code",
+          "expr": "min(zephyrcache_peers_known) == bool on() count(up{job=~\"zephyrcache-.*\"} == 1)",
+          "legendFormat": "Cluster Converged",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Converged",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "aevxy37uxd14wd"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "aevxy37uxd14wd"},
+          "editorMode": "code",
+          "expr": "zephyrcache_peers_known == bool on() group_left() count(up{job=~\"zephyrcache-.*\"} == 1)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Per-Node Convergence",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "aevxy37uxd14wd"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
+      "id": 6,
+      "options": {
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "aevxy37uxd14wd"},
+          "editorMode": "code",
+          "expr": "scalar(count(up{job=~\"zephyrcache-.*\"} == 1)) - zephyrcache_peers_known",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Drift (missing peers per node)",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/deploy/monitoring/prometheus.yml
+++ b/deploy/monitoring/prometheus.yml
@@ -2,6 +2,15 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: "zephyrcache"
+  - job_name: "zephyrcache-seed"
     static_configs:
-      - targets: ["host.docker.internal:8080"]   # service name if in same compose network
+      - targets: ["seed:8080"]
+
+  # The compose service `node` is scaled, so Docker's embedded DNS returns
+  # multiple A records for it. Prometheus's dns_sd resolves all of them and
+  # creates one target per replica — auto-scales with `make up NODES=N`.
+  - job_name: "zephyrcache-nodes"
+    dns_sd_configs:
+      - names: ["node"]
+        type: A
+        port: 8080

--- a/deploy/monitoring/prometheus.yml
+++ b/deploy/monitoring/prometheus.yml
@@ -2,15 +2,20 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: "zephyrcache-seed"
-    static_configs:
-      - targets: ["seed:8080"]
-
-  # The compose service `node` is scaled, so Docker's embedded DNS returns
-  # multiple A records for it. Prometheus's dns_sd resolves all of them and
-  # creates one target per replica — auto-scales with `make up NODES=N`.
   - job_name: "zephyrcache-nodes"
-    dns_sd_configs:
-      - names: ["node"]
-        type: A
-        port: 8080
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    relabel_configs:
+      # Only scrape zephyr node/seed containers
+      - source_labels: [__meta_docker_container_name]
+        regex: /(zephyr-(?:node|seed)-\d+)
+        action: keep
+      # Scrape from the container's internal IP on port 8080
+      - source_labels: [__meta_docker_network_ip]
+        target_label: __address__
+        replacement: $1:8080
+      # Use the container name (strip leading slash) as the instance label
+      - source_labels: [__meta_docker_container_name]
+        regex: /(.+)
+        replacement: $1
+        target_label: instance

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -41,6 +41,17 @@ var (
 		[]string{"op"},
 	)
 
+	// PeersKnown reports cluster size as this node sees it (including itself).
+	// Compare against count(up{job=~"zephyrcache-.*"}) in PromQL to detect
+	// gossip convergence.
+	PeersKnown = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "zephyrcache",
+			Name:      "peers_known",
+			Help:      "Cluster members this node is aware of, including itself.",
+		},
+	)
+
 	// ---- Process / build info ----
 	buildInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -63,7 +74,8 @@ var (
 )
 
 func init() {
-	Registry.MustRegister(RequestsTotal, RequestDuration, InFlight, buildInfo, uptime)
+	Registry.MustRegister(RequestsTotal, RequestDuration, InFlight, PeersKnown, buildInfo, uptime)
+	PeersKnown.Set(1) // before any peers are discovered, the node still sees itself
 }
 
 // MetricsHandler exposes /metrics. Mount it with mux.Handle("/metrics", telemetry.MetricsHandler()).

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pion/dtls/v3"
 
+	"github.com/ryandielhenn/zephyrcache/internal/telemetry"
 	"github.com/ryandielhenn/zephyrcache/pkg/gossip"
 	"github.com/ryandielhenn/zephyrcache/pkg/kv"
 	"github.com/ryandielhenn/zephyrcache/pkg/peer"
@@ -181,6 +182,7 @@ func (n *Node) setPeer(id string, updatedPeer peer.Peer) {
 	if shouldRemove || shouldAdd {
 		peerIds := n.getPeerList()
 		slog.Info("Peers", "peer ids", peerIds)
+		telemetry.PeersKnown.Set(float64(n.countPeers() + 1))
 	}
 }
 
@@ -204,6 +206,9 @@ func (n *Node) syncPeers(newPeers map[string]string) {
 			n.ring.Add(id, addr)
 		}
 	}
+
+	// Ring includes self; len() is the cluster-size view.
+	telemetry.PeersKnown.Set(float64(len(n.ring.Nodes())))
 }
 
 func (n *Node) getPeerMap() map[string]peer.Peer {

--- a/pkg/node/tls.go
+++ b/pkg/node/tls.go
@@ -65,8 +65,13 @@ func GenerateCA() (*CA, error) {
 	}, nil
 }
 
+// ClusterServerName is the synthetic SAN every node cert carries. ClientTLSConfig
+// pins this name so peers can dial each other by container ID or IP without
+// hostname mismatches.
+const ClusterServerName = "zephyr-cluster"
+
 // GenerateNodeCert creates a certificate signed by ca valid for the given hosts
-// (IP addresses or DNS names).
+// (IP addresses or DNS names). ClusterServerName is always added to the SAN list.
 func GenerateNodeCert(ca *CA, hosts []string) (*NodeTLSCreds, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -80,6 +85,7 @@ func GenerateNodeCert(ca *CA, hosts []string) (*NodeTLSCreds, error) {
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
+	template.DNSNames = append(template.DNSNames, ClusterServerName)
 	for _, h := range hosts {
 		if ip := net.ParseIP(h); ip != nil {
 			template.IPAddresses = append(template.IPAddresses, ip)
@@ -130,7 +136,10 @@ func ClientTLSConfig(caPEM []byte, creds *NodeTLSCreds) (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      pool,
-		MinVersion:   tls.VersionTLS13,
+		// All cluster nodes share one cert containing this SAN; pinning to it
+		// lets us dial peers by container ID / IP without hostname mismatch.
+		ServerName: ClusterServerName,
+		MinVersion: tls.VersionTLS13,
 	}, nil
 }
 


### PR DESCRIPTION
Wires TLS into the docker-compose flow so make up TLS=1 brings up an mTLS-secured cluster end-to-end, and fixes the Grafana dashboard so it reflects the whole cluster instead of just the seed.

**TLS for compose**
  - Shared-cert design. --scale makes per-node certs awkward since Docker-assigned container hostnames are random hex IDs. Instead, every node uses the same cert, and ClientTLSConfig pins ServerName: "zephyr-cluster" (a synthetic SAN auto-stamped by GenerateNodeCert). mTLS still enforces "you have a CA-signed cert"; we trade per-node identity / per-node revocation for ops simplicity.

**Tradeoff worth flagging**

Shared cert means a single key compromise = ability to impersonate any node.

**Monitoring fixes**

  - prometheus.yml previously had a single static target which only reached the seed
  - deploy/monitoring/docker-compose.yml now attaches Prometheus and Grafana to the cluster's zephyr_default network as external: true, so they can resolve seed and node directly. 

**Monitoring Cluster Convergence**

We can monitor cluster convergence by comparing the number of jobs that Prometheus sees when identifying scrape targets and comparing this to a node's count of known peers. This PR adds the `known_peers` metric (gauge). Visualizations added to Grafana for knowing if the cluster is converged (min(known_peers) == jobs seen by prometheus), per-node convergence, and per-node peers missing.
<img width="654" height="1382" alt="image" src="https://github.com/user-attachments/assets/7e5c642d-cc2f-4ecc-8e56-0457e92248e2" />


**Test plan**

  - make up (no TLS) — cluster comes up, plaintext as before.
  - make up TLS=1 NODES=5 — cluster comes up, make certs runs, every node logs ConfigureTLS success.
  - PUT/GET against any node works, replication happens over TLS (verify with curl -k https://localhost:443/... from another container or by tcpdump).
  - go test ./pkg/node/... passes (TLS replication tests still green).
  - Bring up monitoring stack, confirm localhost:9090/targets shows seed + every scaled replica green.
  - Send load, verify Grafana panels (Up Status, total requests, requests/sec) all populate.